### PR TITLE
fix: update project when ClusterSetting is successfully stored

### DIFF
--- a/src/views/Projects/ProjectDetail/ClusterSettings.vue
+++ b/src/views/Projects/ProjectDetail/ClusterSettings.vue
@@ -93,6 +93,7 @@ export default class ClusterSettings extends validationMixin {
         if (data?.clusterSettings?.port) {
           this.port = data.clusterSettings.port?.toString();
         }
+        this.$emit('update');
       })
       .catch((err) => {
         this.loading = false;


### PR DESCRIPTION
It seemed like ClusterSetting did save properly - however
the actual problem was the missing update of the parent
components project query.

Fix #47 