### PR TITLE
feat: store orga and sidebar context in localstorage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,9 @@ function initializeUnikubeApp(mode: string) {
       vuetify,
       i18n,
       apolloProvider,
+      beforeCreate() {
+        this.$store.commit('context/initContext');
+      },
       render: (h) => h(App),
     }).$mount('#app');
   }

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -9,13 +9,29 @@ export default class Context extends VuexModule {
 
   organizationMember: TOrganizationMember | null = null;
 
+  sidebarExpanded = false;
+
   @Mutation
   setOrganization(organization: TOrganizationNode): void {
     this.organization = organization;
+    localStorage.setItem('contextOrganization', JSON.stringify(organization.id));
   }
 
   @Mutation
   setOrganizationMember(member: TOrganizationMember): void {
     this.organizationMember = member;
+  }
+
+  @Mutation
+  setSidebarExpansion(expanded: boolean): void {
+    this.sidebarExpanded = expanded;
+    localStorage.setItem('sidebarExpanded', JSON.stringify(expanded));
+  }
+
+  @Mutation
+  initContext(): void {
+    if (localStorage.getItem('sidebarExpanded')) {
+      this.sidebarExpanded = JSON.parse(localStorage.getItem('sidebarExpanded') || 'false');
+    }
   }
 }

--- a/tests/e2e/fixtures/organizations/organization_blueshoe.json
+++ b/tests/e2e/fixtures/organizations/organization_blueshoe.json
@@ -1,0 +1,7 @@
+{
+  "id": "4150dd69-b183-4f8d-96b7-708294e427cd",
+  "title": "Blueshoe",
+  "description": "",
+  "avatarImage": null,
+  "__typename": "OrganizationNode"
+}

--- a/tests/e2e/fixtures/projects/allProjectsQuery.json
+++ b/tests/e2e/fixtures/projects/allProjectsQuery.json
@@ -1,0 +1,34 @@
+{
+  "allProjects": {
+    "totalCount": 2,
+    "results": [
+      {
+        "title": "Unikube Cypress Project",
+        "description": "Description",
+        "currentCommit": "",
+        "currentCommitDateTime": null,
+        "id": "3b181df7-e91c-4a5b-9020-4d1c22636361",
+        "decks": [],
+        "sops": [],
+        "__typename": "ProjectNode",
+        "organization": {
+          "id": "5150dd69-b183-4f8d-96b7-708294e427ce"
+        }
+      },
+      {
+        "title": "Awesome Blueshoe Project",
+        "description": "desc",
+        "currentCommit": "",
+        "currentCommitDateTime": null,
+        "id": "b6138eac-1fd7-487e-8cac-82ef47324fc9",
+        "decks": [],
+        "sops": [],
+        "__typename": "ProjectNode",
+        "organization": {
+          "id": "5150dd69-b183-4f8d-96b7-708294e427ce"
+        }
+      }
+    ],
+    "__typename": "ProjectNodePage"
+  }
+}

--- a/tests/e2e/specs/e2e/loginTest.spec.js
+++ b/tests/e2e/specs/e2e/loginTest.spec.js
@@ -4,25 +4,15 @@ describe('Logs into the app', () => {
     cy.login();
   });
 
-  it('logs in and visits localhost', () => {
-    cy.intercept('POST', '/graphql', (req) => {
-      // eslint-disable-next-line no-prototype-builtins
-      if (req.body.operationName === 'ProjectsQuery') {
-        // eslint-disable-next-line no-param-reassign
-        req.reply({
-          data: {
-            allProjects: {
-              totalCount: 2,
-              results: [{
-                title: 'Unikube Cypress Project', description: 'Description', currentCommit: '', currentCommitDateTime: null, id: '3b181df7-e91c-4a5b-9020-4d1c22636361', decks: [], sops: [], __typename: 'ProjectNode', organization: { id: '5150dd69-b183-4f8d-96b7-708294e427ce' },
-              }, {
-                title: 'Awesome Blueshoe Project', description: 'desc', currentCommit: '', currentCommitDateTime: null, id: 'b6138eac-1fd7-487e-8cac-82ef47324fc9', decks: [], sops: [], __typename: 'ProjectNode', organization: { id: '5150dd69-b183-4f8d-96b7-708294e427ce' },
-              }],
-              __typename: 'ProjectNodePage',
-            },
-          },
-        });
-      }
+  it('logs in and visits overview', () => {
+    cy.fixture('projects/allProjectsQuery.json').then((allProjects) => {
+      cy.intercept('POST', '/graphql', (req) => {
+        if (req.body.operationName === 'ProjectsQuery') {
+          req.reply({
+            data: allProjects,
+          });
+        }
+      });
     });
     cy.visit('/overview');
     cy.get('.project-card__wrapper').should('have.length', 2);

--- a/tests/e2e/specs/e2e/navbar.spec.js
+++ b/tests/e2e/specs/e2e/navbar.spec.js
@@ -1,0 +1,37 @@
+describe('Navbar', () => {
+  beforeEach(() => {
+    cy.viewport('macbook-15');
+    cy.fixture('projects/allProjectsQuery.json').then((allProjects) => {
+      cy.intercept('POST', '/graphql', (req) => {
+        if (req.body.operationName === 'ProjectsQuery') {
+          req.reply({
+            data: allProjects,
+          });
+        }
+      });
+    });
+  });
+
+  it('displays single organization in dropdown', () => {
+    cy.login();
+    cy.visit('/overview');
+    cy.get('.organization-dropdown--item').click();
+    cy.get('.organization-dropdown .v-list .v-list-item').should('have.length', 3);
+    cy.get('.organization-dropdown .v-list .v-list-item').first().should('contain', 'Unikube');
+  });
+
+  it('displays 2 organizations in dropdown', () => {
+    cy.login(true);
+    cy.visit('/overview');
+    cy.get('.organization-dropdown--item').click();
+    cy.get('.organization-dropdown .v-list .v-list-item').should('have.length', 4);
+    cy.get('.organization-dropdown .v-list .v-list-item').first().should('contain', 'Unikube');
+    cy.get('.organization-dropdown .v-list .v-list-item').eq(1).should('contain', 'Blueshoe');
+  });
+
+  it('redirects to create organization view when user has not joined any organization', () => {
+    cy.login(false, true);
+    cy.visit('/overview');
+    cy.location('pathname').should('eq', '/intro');
+  });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import store from '@/store';
 
-Cypress.Commands.add('login', () => {
+Cypress.Commands.add('login', (multipleOrganizations, noOrganization) => {
   // Setup store
   cy.fixture('tokens/rpt.json').then((token) => {
     Cypress.log({ name: 'Login', message: 'Loaded rpt fixture.' });
@@ -11,11 +11,33 @@ Cypress.Commands.add('login', () => {
     );
   });
   cy.fixture('organizations/organization.json').then((organization) => {
-    Cypress.log({ name: 'Login', message: 'Loaded organization fixture.' });
-    store.commit(
-      'context/setOrganization',
-      organization,
-    );
+    cy.fixture('organizations/organization_blueshoe.json').then((organizationBlueshoe) => {
+      Cypress.log({ name: 'Login', message: 'Loaded organization fixture.' });
+      cy.intercept('POST', '/graphql', (req) => {
+        if (req.body.operationName === 'OrganizationsQuery') {
+          const results = [
+            organization,
+          ];
+          if (multipleOrganizations) {
+            results.push(organizationBlueshoe);
+          }
+          if (noOrganization) {
+            results.splice(0, results.length);
+          }
+          req.reply({
+            data: {
+              allOrganizations: {
+                results,
+              },
+            },
+          });
+        }
+      });
+      store.commit(
+        'context/setOrganization',
+        organization,
+      );
+    });
   });
   // Attach store to window before load.
   cy.on('window:before:load', (window) => {


### PR DESCRIPTION
Store some of the application context
variables into localstorage for better UX.
When a user refreshes the page - the sidebar
and the organization are set as before.

Closes #54 