### PR TITLE
fix: update project do not override token

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -72,25 +72,8 @@ type CreateUpdateOrganizationPayload {
   clientMutationId: String
 }
 
-input CreateUpdateProjectInput {
-  title: String!
-  description: String
-  specRepository: String!
-  specRepositoryBranch: String
-  specType: String!
-  currentCommit: String
-  currentCommitDateTime: DateTime
-  accessUsername: String
-  accessToken: String
-  organization: UUID!
-  id: ID
-  clientMutationId: String
-}
-
-type CreateUpdateProjectPayload {
+type CreateUpdateProject {
   project: ProjectNode
-  errors: [ErrorType]
-  clientMutationId: String
 }
 
 type CreateUpdateSOPS {
@@ -193,7 +176,7 @@ type Mutation {
   answerInvitation(accepted: Boolean, id: UUID): UpdateOrganizationMemberInvitation
   updateOrganizationMember(id: UUID, role: OrganizationMemberRoleEnum, user: UUID): UpdateOrganizationMember
   removeOrganizationMember(id: UUID, user: UUID): DeleteOrganizationMember
-  createUpdateProject(input: CreateUpdateProjectInput!): CreateUpdateProjectPayload
+  createUpdateProject(input: ProjectInputType!): CreateUpdateProject
   createProjectMember(id: UUID, role: ProjectMemberRoleEnum, user: UUID): CreateProjectMember
   deleteProjectMember(id: UUID, user: UUID): DeleteProjectMember
   deleteProject(id: UUID): DeleteProject
@@ -250,6 +233,18 @@ type PGPKeyNode {
   description: String
   id: UUID!
   privateKey: String!
+}
+
+input ProjectInputType {
+  title: String!
+  description: String
+  id: UUID
+  specType: SpecicifactionTypeEnum!
+  specRepository: String!
+  specRepositoryBranch: String!
+  accessUsername: String
+  accessToken: String
+  organization: UUID!
 }
 
 type ProjectMember {
@@ -339,6 +334,10 @@ union SOPSProviderNode = AWSKMSNode | PGPKeyNode
 enum SOPSTypeEnum {
   aws
   pgp
+}
+
+enum SpecicifactionTypeEnum {
+  helm
 }
 
 scalar UUID

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -84,26 +84,9 @@ export type TCreateUpdateOrganizationPayload = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
-export type TCreateUpdateProjectInput = {
-  title: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  specRepository: Scalars['String'];
-  specRepositoryBranch?: Maybe<Scalars['String']>;
-  specType: Scalars['String'];
-  currentCommit?: Maybe<Scalars['String']>;
-  currentCommitDateTime?: Maybe<Scalars['DateTime']>;
-  accessUsername?: Maybe<Scalars['String']>;
-  accessToken?: Maybe<Scalars['String']>;
-  organization: Scalars['UUID'];
-  id?: Maybe<Scalars['ID']>;
-  clientMutationId?: Maybe<Scalars['String']>;
-};
-
-export type TCreateUpdateProjectPayload = {
-  __typename?: 'CreateUpdateProjectPayload';
+export type TCreateUpdateProject = {
+  __typename?: 'CreateUpdateProject';
   project?: Maybe<TProjectNode>;
-  errors?: Maybe<Array<Maybe<TErrorType>>>;
-  clientMutationId?: Maybe<Scalars['String']>;
 };
 
 export type TCreateUpdateSops = {
@@ -232,7 +215,7 @@ export type TMutation = {
   answerInvitation?: Maybe<TUpdateOrganizationMemberInvitation>;
   updateOrganizationMember?: Maybe<TUpdateOrganizationMember>;
   removeOrganizationMember?: Maybe<TDeleteOrganizationMember>;
-  createUpdateProject?: Maybe<TCreateUpdateProjectPayload>;
+  createUpdateProject?: Maybe<TCreateUpdateProject>;
   createProjectMember?: Maybe<TCreateProjectMember>;
   deleteProjectMember?: Maybe<TDeleteProjectMember>;
   deleteProject?: Maybe<TDeleteProject>;
@@ -280,7 +263,7 @@ export type TMutationRemoveOrganizationMemberArgs = {
 
 
 export type TMutationCreateUpdateProjectArgs = {
-  input: TCreateUpdateProjectInput;
+  input: TProjectInputType;
 };
 
 
@@ -382,6 +365,18 @@ export type TPgpKeyNode = {
   description?: Maybe<Scalars['String']>;
   id: Scalars['UUID'];
   privateKey: Scalars['String'];
+};
+
+export type TProjectInputType = {
+  title: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['UUID']>;
+  specType: TSpecicifactionTypeEnum;
+  specRepository: Scalars['String'];
+  specRepositoryBranch: Scalars['String'];
+  accessUsername?: Maybe<Scalars['String']>;
+  accessToken?: Maybe<Scalars['String']>;
+  organization: Scalars['UUID'];
 };
 
 export type TProjectMember = {
@@ -540,6 +535,10 @@ export enum TSopsTypeEnum {
   Pgp = 'pgp'
 }
 
+export enum TSpecicifactionTypeEnum {
+  Helm = 'helm'
+}
+
 
 export type TUpdateClusterSettingsInput = {
   port: Scalars['Int'];
@@ -673,7 +672,7 @@ export type TCreateProjectMutationVariables = Exact<{
   title: Scalars['String'];
   description: Scalars['String'];
   specRepository: Scalars['String'];
-  specType: Scalars['String'];
+  specType: TSpecicifactionTypeEnum;
   accessUsername?: Maybe<Scalars['String']>;
   accessToken?: Maybe<Scalars['String']>;
   specRepositoryBranch: Scalars['String'];
@@ -681,22 +680,22 @@ export type TCreateProjectMutationVariables = Exact<{
 }>;
 
 
-export type TCreateProjectMutationResult = { __typename?: 'Mutation', createUpdateProject?: Maybe<{ __typename?: 'CreateUpdateProjectPayload', project?: Maybe<{ __typename?: 'ProjectNode', title: string, id: any }>, errors?: Maybe<Array<Maybe<{ __typename?: 'ErrorType', messages: Array<string>, field: string }>>> }> };
+export type TCreateProjectMutationResult = { __typename?: 'Mutation', createUpdateProject?: Maybe<{ __typename?: 'CreateUpdateProject', project?: Maybe<{ __typename?: 'ProjectNode', title: string, id: any }> }> };
 
 export type TUpdateProjectMutationVariables = Exact<{
   title: Scalars['String'];
   description: Scalars['String'];
   specRepository: Scalars['String'];
-  specType: Scalars['String'];
+  specType: TSpecicifactionTypeEnum;
   accessUsername?: Maybe<Scalars['String']>;
   accessToken?: Maybe<Scalars['String']>;
   specRepositoryBranch: Scalars['String'];
-  id?: Maybe<Scalars['ID']>;
+  id: Scalars['UUID'];
   organization: Scalars['UUID'];
 }>;
 
 
-export type TUpdateProjectMutationResult = { __typename?: 'Mutation', createUpdateProject?: Maybe<{ __typename?: 'CreateUpdateProjectPayload', project?: Maybe<{ __typename?: 'ProjectNode', title: string, id: any }>, errors?: Maybe<Array<Maybe<{ __typename?: 'ErrorType', messages: Array<string>, field: string }>>> }> };
+export type TUpdateProjectMutationResult = { __typename?: 'Mutation', createUpdateProject?: Maybe<{ __typename?: 'CreateUpdateProject', project?: Maybe<{ __typename?: 'ProjectNode', title: string, id: any }> }> };
 
 export type TDeleteProjectMutationVariables = Exact<{
   id?: Maybe<Scalars['UUID']>;
@@ -1020,7 +1019,7 @@ export const ProjectDetailOtherProjectsQuery = gql`
 }
     `;
 export const CreateProject = gql`
-    mutation CreateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $organization: UUID!) {
+    mutation CreateProject($title: String!, $description: String!, $specRepository: String!, $specType: SpecicifactionTypeEnum!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $organization: UUID!) {
   createUpdateProject(
     input: {title: $title, description: $description, specRepository: $specRepository, specType: $specType, specRepositoryBranch: $specRepositoryBranch, accessUsername: $accessUsername, accessToken: $accessToken, organization: $organization}
   ) {
@@ -1028,25 +1027,17 @@ export const CreateProject = gql`
       title
       id
     }
-    errors {
-      messages
-      field
-    }
   }
 }
     `;
 export const UpdateProject = gql`
-    mutation UpdateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $id: ID, $organization: UUID!) {
+    mutation UpdateProject($title: String!, $description: String!, $specRepository: String!, $specType: SpecicifactionTypeEnum!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $id: UUID!, $organization: UUID!) {
   createUpdateProject(
     input: {title: $title, description: $description, specRepository: $specRepository, specType: $specType, specRepositoryBranch: $specRepositoryBranch, accessUsername: $accessUsername, accessToken: $accessToken, organization: $organization, id: $id}
   ) {
     project {
       title
       id
-    }
-    errors {
-      messages
-      field
     }
   }
 }

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -674,8 +674,8 @@ export type TCreateProjectMutationVariables = Exact<{
   description: Scalars['String'];
   specRepository: Scalars['String'];
   specType: Scalars['String'];
-  accessUsername: Scalars['String'];
-  accessToken: Scalars['String'];
+  accessUsername?: Maybe<Scalars['String']>;
+  accessToken?: Maybe<Scalars['String']>;
   specRepositoryBranch: Scalars['String'];
   organization: Scalars['UUID'];
 }>;
@@ -688,8 +688,8 @@ export type TUpdateProjectMutationVariables = Exact<{
   description: Scalars['String'];
   specRepository: Scalars['String'];
   specType: Scalars['String'];
-  accessUsername: Scalars['String'];
-  accessToken: Scalars['String'];
+  accessUsername?: Maybe<Scalars['String']>;
+  accessToken?: Maybe<Scalars['String']>;
   specRepositoryBranch: Scalars['String'];
   id?: Maybe<Scalars['ID']>;
   organization: Scalars['UUID'];
@@ -1020,7 +1020,7 @@ export const ProjectDetailOtherProjectsQuery = gql`
 }
     `;
 export const CreateProject = gql`
-    mutation CreateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String!, $accessToken: String!, $specRepositoryBranch: String!, $organization: UUID!) {
+    mutation CreateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $organization: UUID!) {
   createUpdateProject(
     input: {title: $title, description: $description, specRepository: $specRepository, specType: $specType, specRepositoryBranch: $specRepositoryBranch, accessUsername: $accessUsername, accessToken: $accessToken, organization: $organization}
   ) {
@@ -1036,7 +1036,7 @@ export const CreateProject = gql`
 }
     `;
 export const UpdateProject = gql`
-    mutation UpdateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String!, $accessToken: String!, $specRepositoryBranch: String!, $id: ID, $organization: UUID!) {
+    mutation UpdateProject($title: String!, $description: String!, $specRepository: String!, $specType: String!, $accessUsername: String, $accessToken: String, $specRepositoryBranch: String!, $id: ID, $organization: UUID!) {
   createUpdateProject(
     input: {title: $title, description: $description, specRepository: $specRepository, specType: $specType, specRepositoryBranch: $specRepositoryBranch, accessUsername: $accessUsername, accessToken: $accessToken, organization: $organization, id: $id}
   ) {

--- a/src/graphql/Projects.graphql
+++ b/src/graphql/Projects.graphql
@@ -145,8 +145,8 @@ mutation CreateProject(
   $description: String!
   $specRepository: String!
   $specType: String!
-  $accessUsername: String!
-  $accessToken: String!
+  $accessUsername: String
+  $accessToken: String
   $specRepositoryBranch: String!
   $organization: UUID!
 ) {
@@ -178,8 +178,8 @@ mutation UpdateProject(
   $description: String!
   $specRepository: String!
   $specType: String!
-  $accessUsername: String!
-  $accessToken: String!
+  $accessUsername: String
+  $accessToken: String
   $specRepositoryBranch: String!
   $id: ID
   $organization: UUID!

--- a/src/graphql/Projects.graphql
+++ b/src/graphql/Projects.graphql
@@ -144,7 +144,7 @@ mutation CreateProject(
   $title: String!
   $description: String!
   $specRepository: String!
-  $specType: String!
+  $specType: SpecicifactionTypeEnum!
   $accessUsername: String
   $accessToken: String
   $specRepositoryBranch: String!
@@ -166,10 +166,6 @@ mutation CreateProject(
       title,
       id
     }
-    errors {
-      messages
-      field
-    }
   }
 }
 
@@ -177,11 +173,11 @@ mutation UpdateProject(
   $title: String!
   $description: String!
   $specRepository: String!
-  $specType: String!
+  $specType: SpecicifactionTypeEnum!
   $accessUsername: String
   $accessToken: String
   $specRepositoryBranch: String!
-  $id: ID
+  $id: UUID!
   $organization: UUID!
 ) {
   createUpdateProject(
@@ -200,10 +196,6 @@ mutation UpdateProject(
     project {
       title,
       id
-    }
-    errors {
-      messages
-      field
     }
   }
 }

--- a/src/views/Projects/ProjectForm.vue
+++ b/src/views/Projects/ProjectForm.vue
@@ -150,15 +150,15 @@
 </template>
 
 <script lang="ts">
-import {
-  Component, Prop, Watch,
-} from 'vue-property-decorator';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import {
   CreateProject,
-  UpdateProject,
-  TProjectNode,
   TCreateProjectMutationResult,
-  TCreateProjectMutationVariables, TUpdateProjectMutationVariables,
+  TCreateProjectMutationVariables,
+  TProjectNode,
+  TSpecicifactionTypeEnum,
+  TUpdateProjectMutationVariables,
+  UpdateProject,
 } from '@/generated/graphql';
 import { required, url } from 'vuelidate/lib/validators';
 import VueI18n from 'vue-i18n';
@@ -199,7 +199,7 @@ export default class ProjectForm extends validationMixin {
 
   specRepositoryBranch = 'master';
 
-  specType = 'helm';
+  specType: TSpecicifactionTypeEnum = TSpecicifactionTypeEnum.Helm;
 
   accessUsername = '';
 
@@ -209,7 +209,7 @@ export default class ProjectForm extends validationMixin {
 
   id = '';
 
-  specTypeChoices = ['helm']
+  specTypeChoices = [TSpecicifactionTypeEnum.Helm]
 
   saveLoading = false
 
@@ -247,7 +247,7 @@ export default class ProjectForm extends validationMixin {
       this.description = this.project.description || '';
       this.specRepository = this.project.specRepository;
       this.specRepositoryBranch = this.project.specRepositoryBranch || '';
-      this.specType = this.project.specType.toLowerCase();
+      this.specType = this.project.specType.toLowerCase() as TSpecicifactionTypeEnum;
       this.accessUsername = this.project.accessUsername;
       this.accessToken = this.project.accessUsername;
       this.id = this.project.id;
@@ -310,8 +310,7 @@ export default class ProjectForm extends validationMixin {
         .then(this.success)
         .catch(this.failed);
     } else {
-      const variables: TUpdateProjectMutationVariables = projectVariables;
-      variables.id = this.id;
+      const variables: TUpdateProjectMutationVariables = { ...projectVariables, id: this.id };
       this.$apollo.mutate({
         mutation: UpdateProject,
         variables,


### PR DESCRIPTION
Access username and token are now only
send with the mutation payload when
fields have been changed. Mutation
query was adapted for that purpose.
Remove 'plain' render option since it
is currently not available.

resolves #70 
resolves #69 